### PR TITLE
Migrate to new object syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,28 +55,16 @@ let handler: AwsLambda.APIGatewayProxy.handler =
     | None => Js.log("executing lambda for anonymous user")
     };
     let result =
-      switch (event |. Event.body, event |. Event.isBase64Encoded) {
-      | (None, false) =>
+      switch (event |. Event.body) {
+      | None =>
         Js.log("error: no body available in the request");
         result(
           ~body=`Plain({|{"status": "no body available in the request"}|}),
           ~statusCode=400,
           (),
         );
-      | (None, true) =>
-        Js.log("error: no body available in the request");
-        result(
-          ~body=
-            `Base64(
-              "eyJzdGF0dXMiOiAibm8gYm9keSBhdmFpbGFibGUgaW4gdGhlIHJlcXVlc3QifQ==",
-            ),
-          ~statusCode=400,
-          (),
-        );
-      | (Some(body), false) =>
-        result(~body=`Plain(body), ~statusCode=200, ())
-      | (Some(body), true) =>
-        result(~body=`Base64(body), ~statusCode=200, ())
+      | Some(body) =>
+        Result.make(~statusCode=200, ~body, ~isBase64Encoded=event |. Event.isBase64Encoded, ())
       };
     cb(Js.null, result);
     Js.Promise.resolve();

--- a/example/auth.re
+++ b/example/auth.re
@@ -1,27 +1,31 @@
 let generatePolicy =
     (~context=?, ~principalId, ~effect, ~resource, ())
-    : AwsLambda.APIGatewayAuthorizer.result => {
-  let context = Js.Nullable.fromOption(context);
-  {
-    "principalId": principalId,
-    "context": context,
-    "policyDocument": {
-      "Statement": [|
-        {
-          "Action": [|"execute-api:Invoke"|],
-          "Effect": effect,
-          "Resource": resource,
-        },
-      |],
-      "Version": "2012-10-17",
-    },
-  };
-};
+    : AwsLambda.APIGatewayAuthorizer.Result.t =>
+  AwsLambda.APIGatewayAuthorizer.(
+    Result.make(
+      ~policyDocument=
+        PolicyDocument.make(
+          ~statement=[|
+            Statement.make(
+              ~action=[|"execute-api:Invoke"|],
+              ~effect,
+              ~resource,
+            ),
+          |],
+          ~version="2012-10-17",
+        ),
+      ~principalId,
+      ~context?,
+      (),
+    )
+  );
 
 let handle: AwsLambda.APIGatewayAuthorizer.handler =
   (event, _context, cb) => {
+    open AwsLambda.APIGatewayAuthorizer;
     let token =
-      Js.Nullable.toOption(event##queryStringParameters)
+      event
+      |. Event.queryStringParameters
       |> Js.Option.andThen((. params) => Js.Dict.get(params, "token"));
     switch (token) {
     | Some("secrettoken") =>
@@ -31,21 +35,14 @@ let handle: AwsLambda.APIGatewayAuthorizer.handler =
           generatePolicy(
             ~principalId="myuser",
             ~effect="Allow",
-            ~resource=[|event##methodArn|],
+            ~resource=[|event |. Event.methodArn|],
             (),
           ),
         ),
       );
       Js.Promise.resolve();
     | _ =>
-      cb(
-        Js.Null.return({
-          "name": "Unauthorized",
-          "message": "Unauthorized",
-          "stack": Js.Nullable.null,
-        }),
-        Js.Nullable.null,
-      );
+      cb(Js.Null.return("Unauthorized"), Js.Nullable.null);
       Js.Promise.resolve();
     };
   };

--- a/example/echo.re
+++ b/example/echo.re
@@ -10,28 +10,16 @@ let handler: AwsLambda.APIGatewayProxy.handler =
     | None => Js.log("executing lambda for anonymous user")
     };
     let result =
-      switch (event |. Event.body, event |. Event.isBase64Encoded) {
-      | (None, false) =>
+      switch (event |. Event.body) {
+      | None =>
         Js.log("error: no body available in the request");
         result(
           ~body=`Plain({|{"status": "no body available in the request"}|}),
           ~statusCode=400,
           (),
         );
-      | (None, true) =>
-        Js.log("error: no body available in the request");
-        result(
-          ~body=
-            `Base64(
-              "eyJzdGF0dXMiOiAibm8gYm9keSBhdmFpbGFibGUgaW4gdGhlIHJlcXVlc3QifQ==",
-            ),
-          ~statusCode=400,
-          (),
-        );
-      | (Some(body), false) =>
-        result(~body=`Plain(body), ~statusCode=200, ())
-      | (Some(body), true) =>
-        result(~body=`Base64(body), ~statusCode=200, ())
+      | Some(body) =>
+        Result.make(~statusCode=200, ~body, ~isBase64Encoded=event |. Event.isBase64Encoded, ())
       };
     cb(Js.null, result);
     Js.Promise.resolve();

--- a/example/echo.re
+++ b/example/echo.re
@@ -21,7 +21,10 @@ let handler: AwsLambda.APIGatewayProxy.handler =
       | (None, true) =>
         Js.log("error: no body available in the request");
         result(
-          ~body=`Base64({|{"status": "no body available in the request"}|}),
+          ~body=
+            `Base64(
+              "eyJzdGF0dXMiOiAibm8gYm9keSBhdmFpbGFibGUgaW4gdGhlIHJlcXVlc3QifQ==",
+            ),
           ~statusCode=400,
           (),
         );

--- a/example/echo.re
+++ b/example/echo.re
@@ -1,27 +1,34 @@
 let handler: AwsLambda.APIGatewayProxy.handler =
   (event, _context, cb) => {
+    open AwsLambda.APIGatewayProxy;
     let parameter =
-      Js.Null.toOption(event##queryStringParameters)
+      event
+      |. Event.queryStringParameters
       |> Js.Option.andThen((. params) => Js.Dict.get(params, "userid"));
-    switch parameter {
+    switch (parameter) {
     | Some(userid) => Js.log2("executing lambda for", userid)
     | None => Js.log("executing lambda for anonymous user")
     };
     let result =
-      switch (Js.Null.toOption(event##body)) {
-      | None =>
+      switch (event |. Event.body, event |. Event.isBase64Encoded) {
+      | (None, false) =>
         Js.log("error: no body available in the request");
-        AwsLambda.APIGatewayProxy.result(
+        result(
           ~body=`Plain({|{"status": "no body available in the request"}|}),
           ~statusCode=400,
-          ()
+          (),
         );
-      | Some(body) => {
-          "body": body,
-          "statusCode": 200,
-          "headers": Js.Nullable.null,
-          "isBase64Encoded": Js.Nullable.return(event##isBase64Encoded)
-        }
+      | (None, true) =>
+        Js.log("error: no body available in the request");
+        result(
+          ~body=`Base64({|{"status": "no body available in the request"}|}),
+          ~statusCode=400,
+          (),
+        );
+      | (Some(body), false) =>
+        result(~body=`Plain(body), ~statusCode=200, ())
+      | (Some(body), true) =>
+        result(~body=`Base64(body), ~statusCode=200, ())
       };
     cb(Js.null, result);
     Js.Promise.resolve();

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "@ahrefs/bs-aws-lambda": "file:../",
-    "bs-platform": "^2.2.2"
+    "bs-platform": "^3.0.0"
   },
   "devDependencies": {
     "serverless-offline": "^3.18.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@ahrefs/bs-aws-lambda@file:..":
-  version "0.4.0"
+  version "0.8.0"
 
 abbrev@1:
   version "1.1.1"
@@ -482,9 +482,9 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-bs-platform@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"
+bs-platform@^3.0.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.5.tgz#fb34ee4702bc9163848d5537096c4f31ebaeed40"
 
 buffer-crc32@^0.2.1:
   version "0.2.13"

--- a/src/awsLambda.re
+++ b/src/awsLambda.re
@@ -68,10 +68,10 @@ module Context = {
     [@bs.optional]
     clientContext: ClientContext.t,
   };
-  let make = t;
-};
 
-[@bs.send] external getRemainingTimeInMillis : Context.t => int = "";
+  let make = t;
+  [@bs.send] external getRemainingTimeInMillis : t => int = "";
+};
 
 type error = Js.Nullable.t(Js.Exn.t);
 
@@ -175,7 +175,7 @@ module APIGatewayProxy = {
     let make = t;
   };
 
-  let result = (~headers=?, ~body, ~statusCode, ()) : Result.t => {
+  let result = (~headers=?, ~body, ~statusCode, ()) => {
     let (body, isBase64Encoded) =
       switch (body) {
       | `Plain(body) => (body, false)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-bs-platform@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
+bs-platform@^3.0.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.5.tgz#fb34ee4702bc9163848d5537096c4f31ebaeed40"


### PR DESCRIPTION
Bucklescript has deprecated the `Js.t` syntax in favor of
`[@bs.deriving abstract]`. This switches over all of the code to use
the new syntax and also updates the example.

The types had to be moved into modules so naming collisions were avoided
such as:

```
[@bs.deriving abstract]
type result = {
  statusCode: int
};
```

Would generate at compile time:

```
type result = {
  statusCode: int
};

let result: (~statusCode:int) => result;

let statusCode: result => int;
```

So if you had declared multiple results that were deriving abstract
subsequent ones would override the previous ones. Putting these in
modules solves this issue.

Fixes #8