### PR TITLE
Make APIGatewayProxy.Event fields nullable

### DIFF
--- a/src/awsLambda.re
+++ b/src/awsLambda.re
@@ -183,18 +183,14 @@ module APIGatewayProxy = {
   module Event = {
     [@bs.deriving abstract]
     type t = {
-      [@bs.optional]
-      body: string,
+      body: Js.Nullable.t(string),
       headers: Js.Dict.t(string),
       httpMethod: string,
       isBase64Encoded: bool,
       path: string,
-      [@bs.optional]
-      pathParameters: Js.Dict.t(string),
-      [@bs.optional]
-      queryStringParameters: Js.Dict.t(string),
-      [@bs.optional]
-      stageVariables: Js.Dict.t(string),
+      pathParameters: Js.Nullable.t(Js.Dict.t(string)),
+      queryStringParameters: Js.Nullable.t(Js.Dict.t(string)),
+      stageVariables: Js.Nullable.t(Js.Dict.t(string)),
       requestContext: EventRequestContext.t,
       resource: string,
     };


### PR DESCRIPTION
These changes replaces the previous use of `[@bs.optional]` in `APIGatewayProxy.Event` with `Js.Nullable.t` as field are still present with `null` values when they're empty, rather than not being present at all.

Refs https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/index.d.ts#L58 
Refs https://reasonml.chat/t/bs-optional-and-fields-with-null/1065