### PR TITLE
Remove Promise as return from handler functions

### DIFF
--- a/src/awsLambda.re
+++ b/src/awsLambda.re
@@ -90,10 +90,10 @@ type callback('error, 'return) = (Js.Null.t('error), 'return) => unit;
  * @param callback – optional callback to return information to the caller, otherwise return value is null.
  */
 type handler_error('event) =
-  ('event, Context.t, callback_error) => Js.Promise.t(unit);
+  ('event, Context.t, callback_error) => unit;
 
 type handler('event, 'error, 'return) =
-  ('event, Context.t, callback('error, 'return)) => Js.Promise.t(unit);
+  ('event, Context.t, callback('error, 'return)) => unit;
 
 type handler_default('event, 'return) = handler('event, error, 'return);
 


### PR DESCRIPTION
In order to make the handler functions compatible with how AWS expects them to work, handlers should either (1) invoke the provided callback function with the result or (2) return a `Promise` containing the result.

Previously the handler function signatures prevented us from doing approach nr 2, because the returned `Js.Promise(unit)` could not contain an object with the result.

Therefore going for approach nr 1 where the provided callback should be invoked with the result, and no return value out of the handler functions.

#### Needs to be fixed

- [ ] Ideally the callback provided shouldn't have to be explicitly uncurried by the implementing code with `[@bs]` or similar

Refs #16 